### PR TITLE
chore: API 공통 응답 형식 및 예외 처리 기본 세팅

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ out/
 !.env.example
 application-secret.yml
 application-local.properties
+
+# oh-my-claudecode
+.omc

--- a/src/main/java/com/capstone/logue/global/exception/ErrorCode.java
+++ b/src/main/java/com/capstone/logue/global/exception/ErrorCode.java
@@ -1,0 +1,25 @@
+package com.capstone.logue.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    // Common
+    INVALID_INPUT(HttpStatus.BAD_REQUEST, "C001", "잘못된 입력입니다."),
+    INVALID_TYPE(HttpStatus.BAD_REQUEST, "C002", "잘못된 타입입니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "C003", "지원하지 않는 HTTP 메서드입니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C004", "서버 내부 오류가 발생했습니다."),
+
+    // Auth
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "A001", "인증이 필요합니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "A002", "접근 권한이 없습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/capstone/logue/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/capstone/logue/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,56 @@
+package com.capstone.logue.global.exception;
+
+import com.capstone.logue.global.response.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(LogueException.class)
+    public ResponseEntity<ApiResponse<Void>> handleLogueException(LogueException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        log.warn("[LogueException] code={}, message={}", errorCode.getCode(), errorCode.getMessage());
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(ApiResponse.error(errorCode));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Void>> handleValidationException(MethodArgumentNotValidException e) {
+        log.warn("[ValidationException] {}", e.getMessage());
+        return ResponseEntity
+                .status(ErrorCode.INVALID_INPUT.getHttpStatus())
+                .body(ApiResponse.error(ErrorCode.INVALID_INPUT));
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMessageNotReadable(HttpMessageNotReadableException e) {
+        log.warn("[MessageNotReadable] {}", e.getMessage());
+        return ResponseEntity
+                .status(ErrorCode.INVALID_TYPE.getHttpStatus())
+                .body(ApiResponse.error(ErrorCode.INVALID_TYPE));
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMethodNotSupported(HttpRequestMethodNotSupportedException e) {
+        log.warn("[MethodNotSupported] {}", e.getMessage());
+        return ResponseEntity
+                .status(ErrorCode.METHOD_NOT_ALLOWED.getHttpStatus())
+                .body(ApiResponse.error(ErrorCode.METHOD_NOT_ALLOWED));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+        log.error("[UnhandledException] {}", e.getMessage(), e);
+        return ResponseEntity
+                .status(ErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus())
+                .body(ApiResponse.error(ErrorCode.INTERNAL_SERVER_ERROR));
+    }
+}

--- a/src/main/java/com/capstone/logue/global/exception/LogueException.java
+++ b/src/main/java/com/capstone/logue/global/exception/LogueException.java
@@ -1,0 +1,14 @@
+package com.capstone.logue.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class LogueException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public LogueException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/capstone/logue/global/response/ApiResponse.java
+++ b/src/main/java/com/capstone/logue/global/response/ApiResponse.java
@@ -1,0 +1,39 @@
+package com.capstone.logue.global.response;
+
+import com.capstone.logue.global.exception.ErrorCode;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@JsonInclude(JsonInclude.Include.ALWAYS)
+public class ApiResponse<T> {
+
+    private final boolean success;
+    private final String code;
+    private final String message;
+    private final T data;
+
+    private ApiResponse(boolean success, String code, String message, T data) {
+        this.success = success;
+        this.code = code;
+        this.message = message;
+        this.data = data;
+    }
+
+    public static <T> ApiResponse<T> success(HttpStatus status, String message, T data) {
+        return new ApiResponse<>(true, String.valueOf(status.value()), message, data);
+    }
+
+    public static <T> ApiResponse<T> success(String message, T data) {
+        return success(HttpStatus.OK, message, data);
+    }
+
+    public static ApiResponse<Void> success(String message) {
+        return success(HttpStatus.OK, message, null);
+    }
+
+    public static ApiResponse<Void> error(ErrorCode errorCode) {
+        return new ApiResponse<>(false, errorCode.getCode(), errorCode.getMessage(), null);
+    }
+}


### PR DESCRIPTION
 ## 요약
   - API 공통 성공/실패 응답 형식 및 전역 예외 처리 클래스 구현

   ## 변경 사항
   - [x] 기능
   - [ ] 버그 수정
   - [ ] 리팩토링
   - [ ] 문서
   - [ ] 테스트
   - [x] 기타

   ## 테스트
   - [ ] 로컬 테스트 완료
   - 테스트 방법:
     - ./gradlew build 로 컴파일 확인
     - 각 엔드포인트 호출 후 응답 형식 확인

   ## 스크린샷/로그 (선택)
   - 필요한 경우 첨부

   ## 롤백/리스크
   - 리스크 포인트: 기존 HealthCheckController가 Map 반환 중 → ApiResponse 형식 미적용 상태 (별 상관은 없음) 
   - 롤백 방법: 해당 파일 4개 삭제

   ## 관련 이슈
   Closes #4 