### PR TITLE
chore: 디스코드 커스텀 에러 웹훅을 위한 파일 세팅

### DIFF
--- a/src/main/java/com/capstone/logue/global/config/AppConfig.java
+++ b/src/main/java/com/capstone/logue/global/config/AppConfig.java
@@ -1,0 +1,17 @@
+package com.capstone.logue.global.config;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.web.client.RestTemplate;
+
+@EnableAsync
+@Configuration
+public class AppConfig {
+
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder builder) {
+        return builder.build();
+    }
+}

--- a/src/main/java/com/capstone/logue/global/discord/DiscordWebhookService.java
+++ b/src/main/java/com/capstone/logue/global/discord/DiscordWebhookService.java
@@ -1,0 +1,159 @@
+package com.capstone.logue.global.discord;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Service
+public class DiscordWebhookService {
+
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS");
+    private static final int MAX_DESCRIPTION_LENGTH = 4000;
+    private static final int MAX_STACK_LINES = 15;
+
+    private final RestTemplate restTemplate;
+    private final String webhookUrl;
+    private final String appName;
+    private final String activeProfile;
+
+    public DiscordWebhookService(
+            RestTemplate restTemplate,
+            @Value("${DISCORD_WEBHOOK_URL:}") String webhookUrl,
+            @Value("${spring.application.name:logue}") String appName,
+            @Value("${spring.profiles.active:local}") String activeProfile
+    ) {
+        this.restTemplate = restTemplate;
+        this.webhookUrl = webhookUrl;
+        this.appName = appName;
+        this.activeProfile = activeProfile;
+    }
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void sendStartupNotification() {
+        if (webhookUrl == null || webhookUrl.isBlank()) {
+            return;
+        }
+
+        try {
+            String timestamp = LocalDateTime.now().format(FORMATTER);
+            String description = String.format("""
+                    **🧩 서비스** : %s
+                    **🌐 환경** : %s
+                    **⏰ 시간** : %s
+                    """, appName, activeProfile, timestamp);
+
+            Map<String, Object> embed = Map.of(
+                    "title", "✅ 서버 시작",
+                    "description", description,
+                    "color", 3066993  // green
+            );
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            restTemplate.postForEntity(
+                    webhookUrl,
+                    new HttpEntity<>(Map.of("embeds", List.of(embed)), headers),
+                    String.class
+            );
+        } catch (Exception ex) {
+            log.warn("[Discord] 시작 알림 전송 실패: {}", ex.getMessage());
+        }
+    }
+
+    @Async
+    public void sendErrorNotification(String method, String uri, String errorCode, int httpStatus, Exception e) {
+        if (webhookUrl == null || webhookUrl.isBlank()) {
+            log.debug("[Discord] Webhook URL이 설정되지 않아 알림을 건너뜁니다.");
+            return;
+        }
+
+        try {
+            String description = buildDescription(method, uri, errorCode, httpStatus, e);
+            Map<String, Object> embed = Map.of(
+                    "title", "🚨 에러 로그 🚨",
+                    "description", description,
+                    "color", 15158332  // red
+            );
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            restTemplate.postForEntity(
+                    webhookUrl,
+                    new HttpEntity<>(Map.of("embeds", List.of(embed)), headers),
+                    String.class
+            );
+        } catch (Exception ex) {
+            log.warn("[Discord] 웹훅 전송 실패: {}", ex.getMessage());
+        }
+    }
+
+    private String buildDescription(String method, String uri, String errorCode, int httpStatus, Exception e) {
+        String timestamp = LocalDateTime.now().format(FORMATTER);
+        String location = extractLocation(e);
+        String message = e.getMessage() != null ? e.getMessage() : "(no message)";
+        String stackTrace = buildStackTrace(e);
+
+        String info = String.format("""
+                **🧩 서비스** : %s
+                **🌐 환경** : %s
+                **⏰ 시간** : %s
+                **📍 위치** : %s
+                **🛣️ 요청** : %s %s
+                **🔢 코드/상태** : %s / %d
+                **💬 에러 메시지** : %s
+                """, appName, activeProfile, timestamp, location, method, uri, errorCode, httpStatus, message);
+
+        String codeBlock = "```java\n" + stackTrace + "\n```";
+        String full = info + "\n" + codeBlock;
+
+        if (full.length() > MAX_DESCRIPTION_LENGTH) {
+            int available = MAX_DESCRIPTION_LENGTH - info.length() - 20;
+            if (available > 0 && stackTrace.length() > available) {
+                stackTrace = stackTrace.substring(0, available) + "\n... (truncated)";
+            }
+            full = info + "\n```java\n" + stackTrace + "\n```";
+        }
+
+        return full;
+    }
+
+    private String extractLocation(Exception e) {
+        StackTraceElement[] elements = e.getStackTrace();
+        if (elements == null || elements.length == 0) return "N/A";
+        StackTraceElement top = elements[0];
+        return top.getClassName() + "." + top.getMethodName()
+                + "(" + top.getFileName() + ":" + top.getLineNumber() + ")";
+    }
+
+    private String buildStackTrace(Exception e) {
+        StackTraceElement[] elements = e.getStackTrace();
+        StringBuilder sb = new StringBuilder();
+        sb.append(e.getClass().getName()).append(": ")
+                .append(e.getMessage() != null ? e.getMessage() : "(no message)").append("\n");
+
+        if (elements != null && elements.length > 0) {
+            int limit = Math.min(elements.length, MAX_STACK_LINES);
+            for (int i = 0; i < limit; i++) {
+                sb.append("  at ").append(elements[i]).append("\n");
+            }
+            if (elements.length > limit) {
+                sb.append("  ... ").append(elements.length - limit).append(" more");
+            }
+        }
+
+        return sb.toString().trim();
+    }
+}

--- a/src/main/java/com/capstone/logue/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/capstone/logue/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,9 @@
 package com.capstone.logue.global.exception;
 
+import com.capstone.logue.global.discord.DiscordWebhookService;
 import com.capstone.logue.global.response.ApiResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -10,13 +13,24 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @Slf4j
+@RequiredArgsConstructor
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    private final DiscordWebhookService discordWebhookService;
+
     @ExceptionHandler(LogueException.class)
-    public ResponseEntity<ApiResponse<Void>> handleLogueException(LogueException e) {
+    public ResponseEntity<ApiResponse<Void>> handleLogueException(LogueException e, HttpServletRequest request) {
         ErrorCode errorCode = e.getErrorCode();
         log.warn("[LogueException] code={}, message={}", errorCode.getCode(), errorCode.getMessage());
+
+        if (errorCode.getHttpStatus().is5xxServerError()) {
+            discordWebhookService.sendErrorNotification(
+                    request.getMethod(), request.getRequestURI(),
+                    errorCode.getCode(), errorCode.getHttpStatus().value(), e
+            );
+        }
+
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
                 .body(ApiResponse.error(errorCode));
@@ -47,8 +61,13 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+    public ResponseEntity<ApiResponse<Void>> handleException(Exception e, HttpServletRequest request) {
         log.error("[UnhandledException] {}", e.getMessage(), e);
+        discordWebhookService.sendErrorNotification(
+                request.getMethod(), request.getRequestURI(),
+                ErrorCode.INTERNAL_SERVER_ERROR.getCode(),
+                ErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus().value(), e
+        );
         return ResponseEntity
                 .status(ErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus())
                 .body(ApiResponse.error(ErrorCode.INTERNAL_SERVER_ERROR));

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,3 +9,8 @@ spring.jpa.show-sql=true
 
 # app ?? ??? ?? ?? ??
 spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration,org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration,org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration
+
+# ================================
+# Discord Webhook (set via SSM: DISCORD_WEBHOOK_URL)
+# ================================
+DISCORD_WEBHOOK_URL=


### PR DESCRIPTION
 ## 요약                   
  - 디스코드 커스텀 에러 웹훅을 위한 파일 세팅                              
    - Discord 웹훅으로 서버 에러(5xx) 알림 전송 기능 추가                                                                                                              
    - 앱 시작 시 연결 확인용 시작 알림 전송                                                                                                                            
    - stg/prod 웹훅 URL을 SSM Parameter Store로 분리 관리                                                                                                              
                                                                                                                                                                       
  ## 변경 사항                                                                                                                                                         
  - [x] 기능                                                                                                                                                           
  - [ ] 버그 수정                                                                                                                                                      
  - [ ] 리팩토링
  - [ ] 문서                                                                                                                                                           
  - [ ] 테스트                                                         
  - [x] 기타

  ## 테스트
  - 로컬 테스트 진행 불가능
  - 테스트 방법:                                                                                                                                                       
    - SSM에 `DISCORD_WEBHOOK_URL` 등록 후 배포하여 서버 시작 알림 수신 확인 (현재 등록 완료)
    - 500 에러 발생 엔드포인트 호출 후 Discord 채널에 에러 알림 수신 확인                                                                                              
                                                                                                                                                                       
  ## 스크린샷/로그 (선택)                                                                                                                                              
  - 필요한 경우 첨부                                                                                                                                                   
                                                                                                                                                                       
  ## 롤백/리스크                                                       
  - 리스크 포인트: `DISCORD_WEBHOOK_URL` 미설정 시 알림 전송 스킵 처리되어 서비스 영향 없음
  - 롤백 방법: SSM에서 `DISCORD_WEBHOOK_URL` 값 삭제 시 자동으로 비활성화                                                                                              
                                                                                                                                                                       
  ## 관련 이슈                                                                                                                                                         
Closes #10 