### PR TITLE
chore: ERD v2과 현재 논의사항 기반 엔티티 1차 구현

### DIFF
--- a/src/main/java/com/capstone/logue/global/entity/AnalysisCriteria.java
+++ b/src/main/java/com/capstone/logue/global/entity/AnalysisCriteria.java
@@ -1,0 +1,70 @@
+package com.capstone.logue.global.entity;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.OffsetDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+/**
+ * 사용자가 확인한 분석 기준 확정본을 저장하는 엔티티입니다.
+ */
+@Getter
+@Entity
+@Table(name = "analysis_criteria")
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class AnalysisCriteria {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "metric_id", nullable = false)
+    private MetricMaster metric;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "message_id")
+    private Message message;
+
+    @Column(name = "formula_numerator", nullable = false, length = 50)
+    private String formulaNumerator;
+
+    @Column(name = "formula_denominator", nullable = false, length = 50)
+    private String formulaDenominator;
+
+    @Column(name = "base_date_column", nullable = false, length = 50)
+    private String baseDateColumn;
+
+    @Column(name = "compare_period", nullable = false, length = 255)
+    private String comparePeriod;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "dimensions", nullable = false, columnDefinition = "jsonb")
+    private JsonNode dimensions;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "exclude_conditions", nullable = false, columnDefinition = "jsonb")
+    private JsonNode excludeConditions;
+
+    @Column(name = "is_confirmed", nullable = false)
+    private boolean confirmed;
+
+    @Column(name = "confirmed_at")
+    private OffsetDateTime confirmedAt;
+}

--- a/src/main/java/com/capstone/logue/global/entity/AnalysisResult.java
+++ b/src/main/java/com/capstone/logue/global/entity/AnalysisResult.java
@@ -1,0 +1,71 @@
+package com.capstone.logue.global.entity;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+/**
+ * 메시지에 대한 구조화된 분석 결과를 저장하는 엔티티입니다.
+ */
+@Getter
+@Entity
+@Table(name = "analysis_results")
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class AnalysisResult {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "message_id", nullable = false)
+    private Message message;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "conversation_id", nullable = false)
+    private Conversation conversation;
+
+    @Column(name = "metric", nullable = false, length = 30)
+    private String metric;
+
+    @Column(name = "formula", nullable = false, length = 255)
+    private String formula;
+
+    @Column(name = "base_date", nullable = false, length = 50)
+    private String baseDate;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "dimensions", nullable = false, columnDefinition = "jsonb")
+    private JsonNode dimensions;
+
+    @Column(name = "compare_period", nullable = false, length = 255)
+    private String comparePeriod;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "exclude_conditions", nullable = false, columnDefinition = "jsonb")
+    private JsonNode excludeConditions;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "chart_data", columnDefinition = "jsonb")
+    private JsonNode chartData;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "data_warnings", columnDefinition = "jsonb")
+    private JsonNode dataWarnings;
+}

--- a/src/main/java/com/capstone/logue/global/entity/Conversation.java
+++ b/src/main/java/com/capstone/logue/global/entity/Conversation.java
@@ -1,0 +1,55 @@
+package com.capstone.logue.global.entity;
+
+import com.capstone.logue.global.entity.base.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 사용자와 Logue 간의 대화 세션을 표현하는 엔티티입니다.
+ */
+@Getter
+@Entity
+@Table(name = "conversations")
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Conversation extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "data_source_id", nullable = false)
+    private DataSource dataSource;
+
+    @Column(name = "title", nullable = false, length = 255)
+    private String title;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "conversation", fetch = FetchType.LAZY)
+    private List<Message> messages = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "conversation", fetch = FetchType.LAZY)
+    private List<AnalysisResult> analysisResults = new ArrayList<>();
+}

--- a/src/main/java/com/capstone/logue/global/entity/DataSource.java
+++ b/src/main/java/com/capstone/logue/global/entity/DataSource.java
@@ -1,0 +1,73 @@
+package com.capstone.logue.global.entity;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+/**
+ * 사용자가 업로드한 데이터 소스 파일과 스키마 메타데이터를 저장하는 엔티티입니다.
+ */
+@Getter
+@Entity
+@Table(name = "data_sources")
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class DataSource {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "file_name", nullable = false, length = 255)
+    private String fileName;
+
+    @Column(name = "file_size", nullable = false)
+    private Long fileSize;
+
+    @Column(name = "storage_key", columnDefinition = "TEXT")
+    private String storageKey;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "schema_json", nullable = false, columnDefinition = "jsonb")
+    private JsonNode schemaJson;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "date_status", columnDefinition = "jsonb")
+    private JsonNode dateStatus;
+
+    @Column(name = "row_count", nullable = false)
+    private Integer rowCount;
+
+    @Column(name = "column_count", nullable = false)
+    private Integer columnCount;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "dataSource", fetch = FetchType.LAZY)
+    private List<DataSourceColumn> dataSourceColumns = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "dataSource", fetch = FetchType.LAZY)
+    private List<Conversation> conversations = new ArrayList<>();
+}

--- a/src/main/java/com/capstone/logue/global/entity/DataSourceColumn.java
+++ b/src/main/java/com/capstone/logue/global/entity/DataSourceColumn.java
@@ -1,0 +1,62 @@
+package com.capstone.logue.global.entity;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+/**
+ * 업로드된 데이터 소스의 컬럼별 메타데이터와 시맨틱 분류 결과를 캐싱하는 엔티티입니다.
+ */
+@Getter
+@Entity
+@Table(name = "data_source_columns")
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class DataSourceColumn {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "data_source_id", nullable = false)
+    private DataSource dataSource;
+
+    @Column(name = "column_name", nullable = false, length = 255)
+    private String columnName;
+
+    @Column(name = "data_type", nullable = false, length = 255)
+    private String dataType;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "semantic_role_option_id", nullable = false)
+    private SemanticRoleOption semanticRoleOption;
+
+    @Column(name = "null_ratio", nullable = false)
+    private Double nullRatio;
+
+    @Column(name = "unique_count", nullable = false)
+    private Integer uniqueCount;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "sample_values", columnDefinition = "jsonb")
+    private JsonNode sampleValues;
+
+    @Column(name = "is_confirmed", nullable = false)
+    private boolean confirmed;
+}

--- a/src/main/java/com/capstone/logue/global/entity/DataWarning.java
+++ b/src/main/java/com/capstone/logue/global/entity/DataWarning.java
@@ -1,0 +1,46 @@
+package com.capstone.logue.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 데이터 컬럼 분석 과정에서 사용할 경고 마스터 정보를 저장하는 엔티티입니다.
+ */
+@Getter
+@Entity
+@Table(name = "data_warnings")
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class DataWarning {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "code", nullable = false, length = 50)
+    private String code;
+
+    @Column(name = "name", nullable = false, length = 255)
+    private String name;
+
+    @Column(name = "priority")
+    private Integer priority;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "warning", fetch = FetchType.LAZY)
+    private List<SemanticRoleOption> semanticRoleOptions = new ArrayList<>();
+}

--- a/src/main/java/com/capstone/logue/global/entity/Message.java
+++ b/src/main/java/com/capstone/logue/global/entity/Message.java
@@ -1,0 +1,54 @@
+package com.capstone.logue.global.entity;
+
+import com.capstone.logue.global.entity.base.CreatedTimeEntity;
+import com.capstone.logue.global.entity.enums.MessageRole;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 대화 세션 안에서 오간 개별 메시지를 저장하는 엔티티입니다.
+ */
+@Getter
+@Entity
+@Table(name = "messages")
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Message extends CreatedTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "conversation_id", nullable = false)
+    private Conversation conversation;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false, length = 20)
+    private MessageRole role;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "message", fetch = FetchType.LAZY)
+    private List<AnalysisResult> analysisResults = new ArrayList<>();
+}

--- a/src/main/java/com/capstone/logue/global/entity/MetricDimensionMapping.java
+++ b/src/main/java/com/capstone/logue/global/entity/MetricDimensionMapping.java
@@ -1,0 +1,47 @@
+package com.capstone.logue.global.entity;
+
+import com.capstone.logue.global.entity.base.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 특정 지표에서 허용되는 비교축을 연결하는 매핑 엔티티입니다.
+ */
+@Getter
+@Entity
+@Table(name = "metric_dimension_mapping")
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MetricDimensionMapping extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "metric_id", nullable = false)
+    private MetricMaster metric;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "semantic_role_master_id", nullable = false)
+    private SemanticRoleMaster semanticRoleMaster;
+
+    @Column(name = "display_order")
+    private Integer displayOrder;
+
+    @Column(name = "is_active", nullable = false)
+    private boolean active;
+}

--- a/src/main/java/com/capstone/logue/global/entity/MetricMaster.java
+++ b/src/main/java/com/capstone/logue/global/entity/MetricMaster.java
@@ -1,0 +1,73 @@
+package com.capstone.logue.global.entity;
+
+import com.capstone.logue.global.entity.base.BaseTimeEntity;
+import com.capstone.logue.global.entity.enums.MetricType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 분석에 사용할 지표 정의와 계산식을 관리하는 마스터 엔티티입니다.
+ */
+@Getter
+@Entity
+@Table(name = "metric_master")
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MetricMaster extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "code", nullable = false, length = 50)
+    private String code;
+
+    @Column(name = "name", nullable = false, length = 100)
+    private String name;
+
+    @Column(name = "description", length = 255)
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "metric_type", nullable = false, length = 20)
+    private MetricType metricType;
+
+    @Column(name = "formula_numerator", length = 50)
+    private String formulaNumerator;
+
+    @Column(name = "formula_denominator", length = 50)
+    private String formulaDenominator;
+
+    @Column(name = "aggregation_unit", nullable = false, length = 50)
+    private String aggregationUnit;
+
+    @Column(name = "is_active", nullable = false)
+    private boolean active;
+
+    @Column(name = "display_order")
+    private Integer displayOrder;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "metric", fetch = FetchType.LAZY)
+    private List<AnalysisCriteria> analysisCriteria = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "metric", fetch = FetchType.LAZY)
+    private List<MetricDimensionMapping> metricDimensionMappings = new ArrayList<>();
+}

--- a/src/main/java/com/capstone/logue/global/entity/SemanticRoleMaster.java
+++ b/src/main/java/com/capstone/logue/global/entity/SemanticRoleMaster.java
@@ -1,0 +1,63 @@
+package com.capstone.logue.global.entity;
+
+import com.capstone.logue.global.entity.enums.SelectionType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 컬럼을 어떤 의미 역할로 분류할지 정의하는 시맨틱 롤 마스터 엔티티입니다.
+ */
+@Getter
+@Entity
+@Table(name = "semantic_role_master")
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class SemanticRoleMaster {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "code", nullable = false, length = 50)
+    private String code;
+
+    @Column(name = "name", nullable = false, length = 100)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "selection_type", nullable = false, length = 10)
+    private SelectionType selectionType;
+
+    @Column(name = "is_required", nullable = false)
+    private boolean required;
+
+    @Column(name = "display_order")
+    private Integer displayOrder;
+
+    @Column(name = "is_active", nullable = false)
+    private boolean active;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "master", fetch = FetchType.LAZY)
+    private List<SemanticRoleOption> options = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "semanticRoleMaster", fetch = FetchType.LAZY)
+    private List<MetricDimensionMapping> metricDimensionMappings = new ArrayList<>();
+}

--- a/src/main/java/com/capstone/logue/global/entity/SemanticRoleOption.java
+++ b/src/main/java/com/capstone/logue/global/entity/SemanticRoleOption.java
@@ -1,0 +1,59 @@
+package com.capstone.logue.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 시맨틱 롤 마스터 아래의 실제 선택 옵션과 연결된 경고 정보를 저장하는 엔티티입니다.
+ */
+@Getter
+@Entity
+@Table(name = "semantic_role_option")
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class SemanticRoleOption {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "master_id", nullable = false)
+    private SemanticRoleMaster master;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "warning_id", nullable = false)
+    private DataWarning warning;
+
+    @Column(name = "code", nullable = false, length = 50)
+    private String code;
+
+    @Column(name = "name", nullable = false, length = 100)
+    private String name;
+
+    @Column(name = "display_order")
+    private Integer displayOrder;
+
+    @Column(name = "is_active", nullable = false)
+    private boolean active;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "semanticRoleOption", fetch = FetchType.LAZY)
+    private List<DataSourceColumn> dataSourceColumns = new ArrayList<>();
+}

--- a/src/main/java/com/capstone/logue/global/entity/User.java
+++ b/src/main/java/com/capstone/logue/global/entity/User.java
@@ -1,0 +1,65 @@
+package com.capstone.logue.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Logue 서비스를 사용하는 사용자 정보를 저장하는 엔티티입니다.
+ */
+@Getter
+@Entity
+@Table(name = "users")
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "email", nullable = false, length = 255)
+    private String email;
+
+    @Column(name = "provider_user_id", nullable = false, length = 255)
+    private String providerUserId;
+
+    @Column(name = "name", length = 100)
+    private String name;
+
+    @Column(name = "provider", nullable = false, length = 30)
+    private String provider;
+
+    @Column(name = "profile_image_url", length = 255)
+    private String profileImageUrl;
+
+    @Column(name = "domain", length = 255)
+    private String domain;
+
+    @Column(name = "frequent_work", length = 255)
+    private String frequentWork;
+
+    @Column(name = "data_tool", length = 255)
+    private String dataTool;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
+    private List<DataSource> dataSources = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
+    private List<Conversation> conversations = new ArrayList<>();
+}

--- a/src/main/java/com/capstone/logue/global/entity/base/BaseTimeEntity.java
+++ b/src/main/java/com/capstone/logue/global/entity/base/BaseTimeEntity.java
@@ -1,0 +1,37 @@
+package com.capstone.logue.global.entity.base;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import java.time.OffsetDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 생성 시간과 수정 시간을 공통으로 관리하는 베이스 엔티티입니다.
+ */
+@Getter
+@MappedSuperclass
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class BaseTimeEntity {
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private OffsetDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        OffsetDateTime now = OffsetDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = OffsetDateTime.now();
+    }
+}

--- a/src/main/java/com/capstone/logue/global/entity/base/CreatedTimeEntity.java
+++ b/src/main/java/com/capstone/logue/global/entity/base/CreatedTimeEntity.java
@@ -1,0 +1,26 @@
+package com.capstone.logue.global.entity.base;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PrePersist;
+import java.time.OffsetDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 생성 시간만 공통으로 관리하는 베이스 엔티티입니다.
+ */
+@Getter
+@MappedSuperclass
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class CreatedTimeEntity {
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = OffsetDateTime.now();
+    }
+}

--- a/src/main/java/com/capstone/logue/global/entity/enums/MessageRole.java
+++ b/src/main/java/com/capstone/logue/global/entity/enums/MessageRole.java
@@ -1,0 +1,9 @@
+package com.capstone.logue.global.entity.enums;
+
+/**
+ * 대화 메시지의 발신 주체를 구분하는 역할 값입니다.
+ */
+public enum MessageRole {
+    USER,
+    ASSISTANT
+}

--- a/src/main/java/com/capstone/logue/global/entity/enums/MetricType.java
+++ b/src/main/java/com/capstone/logue/global/entity/enums/MetricType.java
@@ -1,0 +1,10 @@
+package com.capstone.logue.global.entity.enums;
+
+/**
+ * 지표 계산 방식을 구분하는 타입 값입니다.
+ */
+public enum MetricType {
+    RATIO,
+    COUNT,
+    SUM
+}

--- a/src/main/java/com/capstone/logue/global/entity/enums/SelectionType.java
+++ b/src/main/java/com/capstone/logue/global/entity/enums/SelectionType.java
@@ -1,0 +1,9 @@
+package com.capstone.logue.global.entity.enums;
+
+/**
+ * 시맨틱 롤 선택 방식이 단일 선택인지 다중 선택인지 나타내는 값입니다.
+ */
+public enum SelectionType {
+    SINGLE,
+    MULTI
+}


### PR DESCRIPTION
  ## 요약
  - ERD v2와 현재 논의사항을 반영해 분석/대화/데이터소스 도메인의 JPA 엔티티 및 공통 enum/base entity를 1차 구현했습니다.

  ## 변경 사항
  - [x] 기능
  - [ ] 버그 수정
  - [ ] 리팩토링
  - [ ] 문서
  - [x] 테스트
  - [ ] 기타

  ## 테스트
  - [x] 로컬 테스트 완료
  - 테스트 방법:
    - `gradlew test`

  ## 스크린샷/로그 (선택)
  - `BUILD SUCCESSFUL in 20s`

  ## 롤백/리스크
  - 리스크 포인트:
    - ERD와 실제 DB 스키마가 불일치하면 엔티티 매핑 오류가 발생할 수 있습니다.
    - `jsonb` 컬럼(`dimensions`, `exclude_conditions`, `schema_json` 등)과 연관관계 설정이 추후 마이그레이션/쿼리 구현과 어긋날 가능성이 있습니다.
  - 롤백 방법:
    - 해당 커밋을 revert 해서 추가된 엔티티, enum, base entity를 제거합니다.
    - 이미 스키마가 반영됐다면 관련 테이블/컬럼 마이그레이션도 함께 되돌립니다.

  ## 관련 이슈
Closes #12 